### PR TITLE
Fix incorrect image in Create and Deploy JH Image guide

### DIFF
--- a/docs/create_and_deploy_jh_image.md
+++ b/docs/create_and_deploy_jh_image.md
@@ -57,7 +57,7 @@ After creating the robot you need to set the permissions it will possess.
 
 And finally, you need to copy the secret and give it to Thoth. Copy the secret here:
 
-![quay-robot-2](../public/assets/jh_image_howto/quay-secret.png)
+![quay-robot-2](../public/assets/jh_image_howto/quay-secret-cred.png)
 
 This is currently a manual process so just, please, send the secret (the whole yaml) to @harshad16 to have it added.
 


### PR DESCRIPTION
Fixes #26 

Currently the screenshot shown in step 3 [here](https://github.com/aicoe-aiops/data-science-workflows/blob/master/docs/create_and_deploy_jh_image.md#setting-up-the-image-repository) doesn't match the instructions written. This tiny PR fixes that