### PR TITLE
Fix chapter names/links in toc

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -6,29 +6,28 @@ parts:
     - file: docs/setup_environment/odh_and_opf
     - file: docs/setup_environment/JH_access
     - file: docs/setup_environment/remote-storage
-    - file: docs/setup_environment/thoth 
+    - file: docs/setup_environment/thoth
 
   - caption: Develop + Collaborate
     chapters:
     - file: docs/develop_collaborate/thoth-tools
     - file: docs/develop_collaborate/how-to-contribute
-    - file: docs/develop_collaborate/automated-pipelines   
+    - file: docs/develop_collaborate/automated-pipelines
     - file: docs/develop_collaborate/track-metrics-using-kubeflow
     - file: docs/develop_collaborate/create_and_deploy_jh_image
     - file: docs/develop_collaborate/meteorize
     - file: docs/visualization/trino_and_superset
-  
+
   - caption: Serving + Monitoring
-    chapters: 
-    - file: docs/serving_monitoring/monitoring-jh
+    chapters:
+    - file: docs/serving_monitoring/monitor-jh
     - file: docs/serving_monitoring/deploy-models-using-seldon
     - file: docs/serving_monitoring/deploy-custom-model
-   
- 
+
+
   - caption: Project Organization + Structure
-    chapters: 
-    - file: docs/project_structure/getting_started
+    chapters:
+    - file: docs/project_structure/getting-started
     - file: docs/project_structure/project-structure
     - file: docs/project_structure/project-document-template
     - file: docs/project_structure/boards-and-issues
-    


### PR DESCRIPTION
Some chapters listed in the toc were not showing up in the sidebar because the names had typos. This PR fixes those.